### PR TITLE
fix: 支持字符串类型的 min_budget_tokens参数, Issue #27

### DIFF
--- a/internal/taggers/builtin/taggers.go
+++ b/internal/taggers/builtin/taggers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"claude-code-companion/internal/interfaces"
@@ -416,6 +417,12 @@ func NewThinkingTagger(name, tag string, config map[string]interface{}) (interfa
 			minBudgetTokens = int(budgetFloat)
 		} else if budgetInt, ok := budgetInterface.(int); ok {
 			minBudgetTokens = budgetInt
+		} else if budgetStr, ok := budgetInterface.(string); ok {
+			if i, err := strconv.Atoi(budgetStr); err == nil {
+				minBudgetTokens = i
+			} else {
+				return nil, fmt.Errorf("thinking tagger 'min_budget_tokens' must be a number")
+			}
 		} else {
 			return nil, fmt.Errorf("thinking tagger 'min_budget_tokens' must be a number")
 		}


### PR DESCRIPTION
添加对字符串类型min_budget_tokens参数的支持，当传入字符串时会尝试转换为整数。如果转换失败则返回错误，保持与现有数字类型参数相同的错误处理逻辑。
此bug如果不修复，会导致增加了类型为“内置类型”中的“思考模式匹配”，并且输入了“最小 Budget Tokens ”字段内容标记器后，服务器无法启动。